### PR TITLE
adding FOR to cnc_module_MM.cfg

### DIFF
--- a/GameData/CommNetConstellation/cnc_module_MM.cfg
+++ b/GameData/CommNetConstellation/cnc_module_MM.cfg
@@ -1,5 +1,5 @@
 // Add the CNConstellationModule to all parts contained ModuleCommand i.e. the command and probe parts
-@PART[*]:HAS[@MODULE[ModuleCommand]]
+@PART[*]:HAS[@MODULE[ModuleCommand]]:FOR[zzzzCommNetConstellation]
 {
 	MODULE
 	{
@@ -8,7 +8,7 @@
 }
 
 // Add the CNConstellationAntennaModule to all parts contained ModuleDataTransmitter i.e. antennas, probe cores and manned cockpits
-@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]
+@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:FOR[zzzzCommNetConstellation]
 {
 	MODULE
 	{
@@ -17,7 +17,7 @@
 }
 
 // Deployed Experiment Control Station has internal antenna
-@PART[*]:HAS[@MODULE[ModuleGroundExpControl]]
+@PART[*]:HAS[@MODULE[ModuleGroundExpControl]]:FOR[zzzzCommNetConstellation]
 {
 	MODULE
 	{


### PR DESCRIPTION
This makes some parts like the Kerbalism Antenna
GameData/KerbalismConfig/Parts/ShortAntenna/kerbalism-antenna.cfg
aka. "Communotron 8" get the necessary modules from CommNetConstellation.
The part's main config got no modules at all, they're provided by patches later - after CommNetConstellation did its job.
This is now fixed.