### PR TITLE
LegacyOrbitLineColor setting

### DIFF
--- a/GameData/CommNetConstellation/Localization/en-us.cfg
+++ b/GameData/CommNetConstellation/Localization/en-us.cfg
@@ -80,6 +80,7 @@ Localization
         #CNC_ConstellationControl_vesselSetup_title = Vessel - <color=#00ff00>Setup</color>
         #CNC_ConstellationControl_GroundStationEdit_title = Ground station - <color=#00ff00>Edit</color>
         #CNC_ConstellationControl_toggleStationButton = Hide all station markers
+        #CNC_ConstellationControl_toggleOrbitButton = Toggle colorized orbits
 
         #CNC_ConstellationEdit_description = You are creating a new constellation.
         #CNC_ConstellationEdit_description2 = You are editing Constellation '<<1>>'.

--- a/GameData/CommNetConstellation/Localization/zh-cn.cfg
+++ b/GameData/CommNetConstellation/Localization/zh-cn.cfg
@@ -80,6 +80,7 @@ Localization
         #CNC_ConstellationControl_vesselSetup_title = 载具 - <color=#00ff00>配置</color>
         #CNC_ConstellationControl_GroundStationEdit_title = 地面站 - <color=#00ff00>编辑</color>
         #CNC_ConstellationControl_toggleStationButton = 隐藏所有地面站标记
+        #CNC_ConstellationControl_toggleOrbitButton = Toggle colorized orbits
 
         #CNC_ConstellationEdit_description = 你正在建立一个新的星座. 
         #CNC_ConstellationEdit_description2 = 你在编辑星座 '<<1>>'.

--- a/GameData/CommNetConstellation/cnc_settings.cfg
+++ b/GameData/CommNetConstellation/cnc_settings.cfg
@@ -4,6 +4,7 @@ CommNetConstellationSettings
     DefaultPublicName = Public Broadcasting
     DefaultPublicColor = 0.65, 0.65, 0.65, 1
     DistanceToHideGroundStations = 8000000
+    LegacyOrbitLineColor = false
     Constellations
     {
         Constellation

--- a/GameData/CommNetConstellation/cnc_settings.cfg
+++ b/GameData/CommNetConstellation/cnc_settings.cfg
@@ -4,7 +4,7 @@ CommNetConstellationSettings
     DefaultPublicName = Public Broadcasting
     DefaultPublicColor = 0.65, 0.65, 0.65, 1
     DistanceToHideGroundStations = 8000000
-    LegacyOrbitLineColor = false
+    LegacyOrbitLineColor = False
     Constellations
     {
         Constellation

--- a/src/CommNetConstellation/CNCSettings.cs
+++ b/src/CommNetConstellation/CNCSettings.cs
@@ -45,6 +45,7 @@ namespace CommNetConstellation
         [Persistent] public string DefaultPublicName;
         [Persistent] public Color DefaultPublicColor;
         [Persistent] public float DistanceToHideGroundStations;
+        [Persistent] public bool LegacyOrbitLineColor = false;
         [Persistent(collectionIndex = "Constellation")] public List<Constellation> Constellations;
         [Persistent(collectionIndex = "GroundStation")] public List<CNCCommNetHome> GroundStations;
         //-----

--- a/src/CommNetConstellation/CNCSettings.cs
+++ b/src/CommNetConstellation/CNCSettings.cs
@@ -45,7 +45,7 @@ namespace CommNetConstellation
         [Persistent] public string DefaultPublicName;
         [Persistent] public Color DefaultPublicColor;
         [Persistent] public float DistanceToHideGroundStations;
-        [Persistent] public bool LegacyOrbitLineColor = false;
+        [Persistent] public bool LegacyOrbitLineColor;
         [Persistent(collectionIndex = "Constellation")] public List<Constellation> Constellations;
         [Persistent(collectionIndex = "GroundStation")] public List<CNCCommNetHome> GroundStations;
         //-----

--- a/src/CommNetConstellation/CommNetLayer/CNCCommNetScenario.cs
+++ b/src/CommNetConstellation/CommNetLayer/CNCCommNetScenario.cs
@@ -182,6 +182,9 @@ namespace CommNetConstellation.CommNetLayer
                         case "HideGroundStations":
                             this.hideGroundStations = Boolean.Parse(value.value);
                             break;
+                        case "LegacyOrbitLineColor":
+                            CNCSettings.Instance.LegacyOrbitLineColor = Boolean.Parse(value.value);
+                            break;
                     }
                 }
 
@@ -261,6 +264,7 @@ namespace CommNetConstellation.CommNetLayer
                 gameNode.AddValue("DisplayModeTracking", CNCCommNetUI.CustomModeTrackingStation);
                 gameNode.AddValue("DisplayModeFlight", CNCCommNetUI.CustomModeFlightMap);
                 gameNode.AddValue("HideGroundStations", this.hideGroundStations);
+                gameNode.AddValue("LegacyOrbitLineColor", CNCSettings.Instance.LegacyOrbitLineColor);
 
                 //Constellations
                 if (gameNode.HasNode("Constellations"))

--- a/src/CommNetConstellation/CommNetLayer/CNCCommNetUI.cs
+++ b/src/CommNetConstellation/CommNetLayer/CNCCommNetUI.cs
@@ -136,14 +136,17 @@ namespace CommNetConstellation.CommNetLayer
                 {
                     iconData.color = Color.grey;
                 }
-                else if (CNCSettings.Instance.LegacyOrbitLineColor)
-                {
-                    iconData.color = Constellation.getColor(thisVessel.getStrongestFrequency());
-                    thisVessel.Vessel.orbitRenderer.orbitColor = Constellation.getColor(thisVessel.getStrongestFrequency()).linear;
-                }
                 else
                 {
                     iconData.color = Constellation.getColor(thisVessel.getStrongestFrequency());
+                    if (CNCSettings.Instance.LegacyOrbitLineColor)
+                    {
+                        thisVessel.Vessel.orbitRenderer.orbitColor = iconData.color.linear;
+                    }
+                    else
+                    {
+                        thisVessel.Vessel.orbitRenderer.orbitColor = new Color(0.355f, 0.355f, 0.355f, 1f); //stock color
+                    }
                 }
             }
         }

--- a/src/CommNetConstellation/CommNetLayer/CNCCommNetUI.cs
+++ b/src/CommNetConstellation/CommNetLayer/CNCCommNetUI.cs
@@ -133,9 +133,18 @@ namespace CommNetConstellation.CommNetLayer
             if(thisVessel != null && node.mapObject.type == MapObject.ObjectType.Vessel)
             {
                 if (thisVessel.getStrongestFrequency() < 0) // blind vessel
+                {
                     iconData.color = Color.grey;
-                else
+                }
+                else if (CNCSettings.Instance.LegacyOrbitLineColor)
+                {
                     iconData.color = Constellation.getColor(thisVessel.getStrongestFrequency());
+                    thisVessel.Vessel.orbitRenderer.orbitColor = Constellation.getColor(thisVessel.getStrongestFrequency()).linear;
+                }
+                else
+                {
+                    iconData.color = Constellation.getColor(thisVessel.getStrongestFrequency());
+                }
             }
         }
 

--- a/src/CommNetConstellation/UI/ConstellationControlDialog.cs
+++ b/src/CommNetConstellation/UI/ConstellationControlDialog.cs
@@ -107,8 +107,11 @@ namespace CommNetConstellation.UI
             List<DialogGUIBase> constellationComponments = new List<DialogGUIBase>();
 
             DialogGUIButton createButton = new DialogGUIButton(Localizer.Format("#CNC_ConstellationControl_createButton"), newConstellationClick, false);//"New constellation"
+            DialogGUIToggleButton toggleOrbitButton = new DialogGUIToggleButton(CNCSettings.Instance.LegacyOrbitLineColor, Localizer.Format("#CNC_ConstellationControl_toggleOrbitButton"), delegate (bool b) { CNCSettings.Instance.LegacyOrbitLineColor = !CNCSettings.Instance.LegacyOrbitLineColor; }, 35, 25);//"Toggle colorized orbits"
             DialogGUIHorizontalLayout creationGroup = new DialogGUIHorizontalLayout(true, false, 4, new RectOffset(), TextAnchor.MiddleLeft, new DialogGUIBase[] { new DialogGUIFlexibleSpace(), createButton, new DialogGUIFlexibleSpace() });
+            DialogGUIHorizontalLayout toggleGroup = new DialogGUIHorizontalLayout(true, false, 4, new RectOffset(), TextAnchor.MiddleLeft, new DialogGUIBase[] { new DialogGUIFlexibleSpace(), toggleOrbitButton, new DialogGUIFlexibleSpace() });
             constellationComponments.Add(creationGroup);
+            constellationComponments.Add(toggleGroup);
 
             for (int i = 0; i < CNCCommNetScenario.Instance.constellations.Count; i++)
                 constellationComponments.Add(createConstellationRow(CNCCommNetScenario.Instance.constellations[i]));


### PR DESCRIPTION
A long time ago, CNC used to color the orbit lines the same color as the ship's frequency. This adds a setting to enable this.