### PR TITLE
MM cfg: FOR -> BEFORE[NearFutureExploration]

### DIFF
--- a/GameData/CommNetConstellation/cnc_module_MM.cfg
+++ b/GameData/CommNetConstellation/cnc_module_MM.cfg
@@ -48,7 +48,7 @@
 // Third-party mods
 ////////////
 // Targeting NearFutureExploration that replaces ModuleDataTransmitter with own ModuleDataTransmitterFeedeable during MM patching order
-@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:FOR[NearFutureExploration]
+@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:BEFORE[NearFutureExploration]
 {
 	MODULE
 	{

--- a/GameData/CommNetConstellation/cnc_module_MM.cfg
+++ b/GameData/CommNetConstellation/cnc_module_MM.cfg
@@ -11,7 +11,8 @@
 }
 
 // Add the CNConstellationAntennaModule to all parts contained ModuleDataTransmitter i.e. antennas, probe cores and manned cockpits
-@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:FOR[zzzzCommNetConstellation]:NEEDS[!NearFutureExploration]
+// Also targets derivatives like ModuleDataTransmitterFeedeable from NearFutureExploration
+@PART[*]:HAS[@MODULE[ModuleDataTransmitter*]]:FOR[zzzzCommNetConstellation]
 {
 	MODULE
 	{
@@ -42,16 +43,3 @@
 //		name = CNConstellationAntennaModule
 //	}
 //}
-
-
-////////////
-// Third-party mods
-////////////
-// Targeting NearFutureExploration that replaces ModuleDataTransmitter with own ModuleDataTransmitterFeedeable during MM patching order
-@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:BEFORE[NearFutureExploration]
-{
-	MODULE
-	{
-		name = CNConstellationAntennaModule
-	}
-}


### PR DESCRIPTION
The patch :FOR[NearFutureExploration] runs always and creates the tag "NearFutureExploration", so any other patches that reference NFE in a :NEEDS clause also run, even if that mod is not installed.