### PR TITLE
Reverse order when sort by launch time (newest on Top)

### DIFF
--- a/src/CommNetConstellation/UI/ConstellationControlDialog.cs
+++ b/src/CommNetConstellation/UI/ConstellationControlDialog.cs
@@ -421,7 +421,7 @@ namespace CommNetConstellation.UI
                     allVessels.Sort((x, y) => x.Vessel.mainBody.name.CompareTo(y.Vessel.mainBody.name));
                     break;
                 default:
-                    allVessels.Sort((x, y) => x.Vessel.launchTime.CompareTo(y.Vessel.launchTime));
+                    allVessels.Sort((x, y) => y.Vessel.launchTime.CompareTo(x.Vessel.launchTime));
                     break;
             }
 


### PR DESCRIPTION
If you have a long vessel list, it is better the newest vessel is always first. 